### PR TITLE
install.sh: swallow find error on non-existing /etc/keepassxc-unlock

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -182,7 +182,7 @@ while IFS= read -r -d $'\0' old_conf; do
       fi
     fi
   fi
-done < <(sudo find /etc/keepassxc-unlock -maxdepth 2 -mindepth 2 -name '*.conf' -print0)
+done < <(sudo find /etc/keepassxc-unlock -maxdepth 2 -mindepth 2 -name '*.conf' -print0 2>/dev/null)
 
 echo
 echo -e "${fg_orange}Start user-specific auto-unlock service? This will only work if"


### PR DESCRIPTION
Without it, fresh installation shows following find error:
```console
/snip/
Installing binaries in /usr/local/sbin
Reloading systemd daemon
Enabling and starting login monitor service
Created symlink '/etc/systemd/system/graphical.target.wants/keepassxc-login-monitor.service' → '/etc/systemd/system/keepassxc-login-monitor.service'.
Fetching LICENSE and doc files and installing in /usr/local/share/doc


find: ‘/etc/keepassxc-unlock’: No such file or directory                       # <---- !!

Start user-specific auto-unlock service? This will only work if
this is an upgrade and KDBX databases have already been registered using
keepassxc-unlock-setup previously and KeePassXC is running in the current session.
Proceed? (y/N) 

Installation complete.
```